### PR TITLE
Fix submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rixcalc"]
 	path = rixcalc
-	url = https://github.com/wwright-slac/rixcalc
+	url = git@github.com:pcdshub/rixcalc.git


### PR DESCRIPTION
The rixcalc submodule was linked to the wwright-slac github repo, as opposed to the pcdshub repo. This PR changes that.